### PR TITLE
fix(server): ignore duplicate startGame requests during restart

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -534,8 +534,10 @@ async function handleStartGame(): Promise<void> {
       gameLoop.removeAllListeners();
       gameLoop = null;
     } else {
-      console.error('Game loop already running. Cannot start a new game.');
-      throw new Error('Game loop already running. Cannot start a new game.');
+      // Game is already running - silently ignore duplicate startGame requests
+      // This can happen during restart when client sends startGame after server already started it
+      console.log('Game loop already running. Ignoring duplicate startGame request.');
+      return;
     }
   }
   console.log('Starting game...');


### PR DESCRIPTION
Prevent error when client sends startGame after server already started a new game during restart.

Changes:
- Change handleStartGame to silently ignore duplicate requests instead of throwing error
- Log message instead of error when game loop already running
- Prevents 'Game loop already running' error during restart

This handles the case where client sends startGame event after restartGame already started a new game on the server.

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
