### PR TITLE
Feature/3-4-player-support

### DIFF
--- a/src/agents/ExhaustiveSimpleAgent.ts
+++ b/src/agents/ExhaustiveSimpleAgent.ts
@@ -9,7 +9,11 @@ const DEBUG_TIMING = process.env.DEBUG_SIMPLE_AGENT_TIMING === 'true';
 export class ExhaustiveSimpleAgent extends RandomAgent {
   playerId: string = AGENT_ID;
   human = false;
-  cribbageGame: CribbageGame = new CribbageGame([]);
+  // Use dummy players for internal game (only used for generateDeck())
+  cribbageGame: CribbageGame = new CribbageGame([
+    { id: 'dummy-1', name: 'Dummy 1' },
+    { id: 'dummy-2', name: 'Dummy 2' },
+  ]);
 
   constructor() {
     super();

--- a/src/core/CribbageGame.ts
+++ b/src/core/CribbageGame.ts
@@ -91,6 +91,11 @@ export class CribbageGame extends EventEmitter {
   }
 
   private updatePlayerScore(player: Player, points: number): void {
+    // Only move pegs when the player's score actually increases
+    if (points <= 0) {
+      return;
+    }
+
     // Move current peg position to previous
     player.pegPositions.previous = player.pegPositions.current;
     // Update the actual score first

--- a/src/core/CribbageGame.ts
+++ b/src/core/CribbageGame.ts
@@ -93,10 +93,10 @@ export class CribbageGame extends EventEmitter {
   private updatePlayerScore(player: Player, points: number): void {
     // Move current peg position to previous
     player.pegPositions.previous = player.pegPositions.current;
-    // Update current peg to new score position
-    player.pegPositions.current = player.score + points;
-    // Update the actual score
+    // Update the actual score first
     player.score += points;
+    // Update current peg to new score position
+    player.pegPositions.current = player.score;
   }
 
   private recordGameEvent(

--- a/src/gameplay/GameLoop.ts
+++ b/src/gameplay/GameLoop.ts
@@ -22,6 +22,7 @@ import {
 import { displayCard, parseCard, suitToEmoji } from '../core/scoring';
 import EventEmitter from 'eventemitter3';
 import dotenv from 'dotenv';
+import { getPlayerCountConfig } from './rules';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
 dotenv.config();
@@ -444,8 +445,9 @@ export class GameLoop extends EventEmitter {
     // Request discards from ALL players in parallel
     const discardRequests: DecisionRequest[] = [];
     const gameState = this.cribbageGame.getGameState();
-    const numberOfCardsToDiscard =
-      gameState.players.length === 2 ? 2 : 1;
+    // Get discard count based on player count configuration
+    const config = getPlayerCountConfig(gameState.players.length);
+    const numberOfCardsToDiscard = config.discardPerPlayer;
 
     for (const player of gameState.players) {
       const request = this.requestDecision(

--- a/src/gameplay/rules.ts
+++ b/src/gameplay/rules.ts
@@ -1,0 +1,89 @@
+/**
+ * Centralized configuration for multi-player game rules
+ * Supports 2, 3, and 4 player games with proper card distribution and crib handling
+ */
+
+export interface PlayerCountConfig {
+  handSize: number;           // Cards dealt to each player
+  discardPerPlayer: number;   // Cards each player must discard to crib
+  autoCribCardsFromDeck: number; // Cards auto-dealt to crib from deck (before player dealing)
+}
+
+/**
+ * Get the list of supported player counts
+ * @returns Array of valid player counts [2, 3, 4]
+ */
+export function getSupportedPlayerCounts(): number[] {
+  return [2, 3, 4];
+}
+
+/**
+ * Check if a player count is supported
+ * @param playerCount - Number of players to validate
+ * @returns True if the player count is supported
+ */
+export function isValidPlayerCount(playerCount: number): boolean {
+  return getSupportedPlayerCounts().includes(playerCount);
+}
+
+/**
+ * Get configuration for a specific player count
+ * @param playerCount - Number of players in the game
+ * @returns Configuration for hand size, discard count, and auto-crib cards
+ * @throws Error if player count is not supported
+ */
+export function getPlayerCountConfig(playerCount: number): PlayerCountConfig {
+  if (!isValidPlayerCount(playerCount)) {
+    throw new Error(
+      `Unsupported player count: ${playerCount}. Supported counts are: ${getSupportedPlayerCounts().join(', ')}`
+    );
+  }
+
+  switch (playerCount) {
+    case 2:
+      return {
+        handSize: 6,
+        discardPerPlayer: 2,
+        autoCribCardsFromDeck: 0,
+      };
+    case 3:
+      return {
+        handSize: 5,
+        discardPerPlayer: 1,
+        autoCribCardsFromDeck: 1, // One card auto-dealt to crib
+      };
+    case 4:
+      return {
+        handSize: 5,
+        discardPerPlayer: 1,
+        autoCribCardsFromDeck: 0,
+      };
+    default:
+      // Should never reach here due to isValidPlayerCount check
+      throw new Error(`Unsupported player count: ${playerCount}`);
+  }
+}
+
+/**
+ * Calculate the expected crib size after all discards
+ * @param playerCount - Number of players in the game
+ * @returns Total number of cards that should be in the crib
+ */
+export function getExpectedCribSize(playerCount: number): number {
+  const config = getPlayerCountConfig(playerCount);
+  return playerCount * config.discardPerPlayer + config.autoCribCardsFromDeck;
+}
+
+/**
+ * Validate that a player count is within supported range and throw if not
+ * Used for constructor validation
+ * @param playerCount - Number of players to validate
+ * @throws Error if player count is invalid
+ */
+export function validatePlayerCount(playerCount: number): void {
+  if (playerCount < 2 || playerCount > 4) {
+    throw new Error(
+      `Invalid player count: ${playerCount}. Games must have between 2 and 4 players.`
+    );
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -569,11 +569,11 @@ async function handleStartGame(): Promise<void> {
   const botsNeeded = Math.max(0, requestedPlayerCount - connectedPlayers.size);
   console.log(`Current players: ${connectedPlayers.size}, Bots needed: ${botsNeeded}`);
   
-  // Friendly bot names
+  // Friendly bot names with "Bot " prefix
   const botNames = [
-    'Chip',
-    'Shuffle',
-    'Lucky',
+    'Bot Alex',
+    'Bot Morgan',
+    'Bot Jordan',
   ];
   
   for (let i = 0; i < botsNeeded; i++) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -573,7 +573,8 @@ async function handleStartGame(): Promise<void> {
     const botNumber = i + 1;
     const botName = `Bot ${botNumber}`;
     const botAgent = new ExhaustiveSimpleAgent();
-    const botId = botAgent.playerId;
+    // Create unique bot ID by appending timestamp and counter to avoid collisions
+    const botId = `${botAgent.playerId}-${Date.now()}-${i}`;
     const botPlayerInfo: PlayerInfo = {
       id: botId,
       name: botName,

--- a/src/server.ts
+++ b/src/server.ts
@@ -281,6 +281,7 @@ const playAgainVotes: Set<string> = new Set();
 let gameLoop: GameLoop | null = null;
 let mostRecentGameSnapshot: GameSnapshot | null = null;
 let currentRoundGameEvents: GameEvent[] = [];
+let requestedPlayerCount: number = 2; // Track requested player count for current game
 
 // Generate unique player ID from username, handling conflicts
 function getUniquePlayerId(username: string, socketId: string): string {
@@ -324,6 +325,21 @@ io.on('connection', socket => {
 
   socket.on('startGame', () => {
     console.log('Received startGame event from socket:', socket.id);
+    requestedPlayerCount = 2; // Default to 2-player game
+    handleStartGame().catch(error => {
+      console.error('Error starting game:', error);
+    });
+  });
+
+  socket.on('startGameWithPlayerCount', (data: { playerCount: number }) => {
+    console.log('Received startGameWithPlayerCount event from socket:', socket.id, 'playerCount:', data?.playerCount);
+    const playerCount = data?.playerCount;
+    if (!playerCount || playerCount < 2 || playerCount > 4) {
+      console.error('Invalid player count:', playerCount);
+      socket.emit('error', { message: 'Player count must be between 2 and 4' });
+      return;
+    }
+    requestedPlayerCount = playerCount;
     handleStartGame().catch(error => {
       console.error('Error starting game:', error);
     });
@@ -540,11 +556,22 @@ async function handleStartGame(): Promise<void> {
       return;
     }
   }
-  console.log('Starting game...');
-  // If only one player is connected, add a bot
-  if (connectedPlayers.size === 1) {
-    console.log('Adding a bot to start the game.');
-    const botName = 'Simple Optimal Bot';
+  
+  console.log(`Starting game... (requested player count: ${requestedPlayerCount})`);
+  
+  // Validate requested player count
+  if (requestedPlayerCount < 2 || requestedPlayerCount > 4) {
+    console.error(`Invalid player count: ${requestedPlayerCount}. Must be between 2 and 4.`);
+    return;
+  }
+  
+  // Add bots to fill empty seats
+  const botsNeeded = Math.max(0, requestedPlayerCount - connectedPlayers.size);
+  console.log(`Current players: ${connectedPlayers.size}, Bots needed: ${botsNeeded}`);
+  
+  for (let i = 0; i < botsNeeded; i++) {
+    const botNumber = i + 1;
+    const botName = `Bot ${botNumber}`;
     const botAgent = new ExhaustiveSimpleAgent();
     const botId = botAgent.playerId;
     const botPlayerInfo: PlayerInfo = {
@@ -553,11 +580,16 @@ async function handleStartGame(): Promise<void> {
       agent: botAgent,
     };
     connectedPlayers.set(botId, botPlayerInfo);
+    console.log(`Added bot ${botNumber} (ID: ${botId})`);
   }
 
-  if (connectedPlayers.size < 2) {
-    console.log('Not enough players to start the game.');
+  if (connectedPlayers.size < requestedPlayerCount) {
+    console.log(`Not enough players to start the game. Expected ${requestedPlayerCount}, got ${connectedPlayers.size}.`);
     return;
+  }
+  
+  if (connectedPlayers.size > requestedPlayerCount) {
+    console.log(`Warning: More players than requested. Expected ${requestedPlayerCount}, got ${connectedPlayers.size}. Game will proceed with all players.`);
   }
 
   const playersIdAndName: PlayerIdAndName[] = [];
@@ -692,7 +724,8 @@ async function handleRestartGame(): Promise<void> {
   // Emit game reset event to all clients
   io.emit('gameReset');
 
-  // Start a new game
+  // Start a new game with the same player count
+  console.log(`Restarting with ${requestedPlayerCount} players`);
   await handleStartGame();
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -569,9 +569,15 @@ async function handleStartGame(): Promise<void> {
   const botsNeeded = Math.max(0, requestedPlayerCount - connectedPlayers.size);
   console.log(`Current players: ${connectedPlayers.size}, Bots needed: ${botsNeeded}`);
   
+  // Friendly bot names
+  const botNames = [
+    'Chip',
+    'Shuffle',
+    'Lucky',
+  ];
+  
   for (let i = 0; i < botsNeeded; i++) {
-    const botNumber = i + 1;
-    const botName = `Bot ${botNumber}`;
+    const botName = botNames[i] || `Bot ${i + 1}`;
     const botAgent = new ExhaustiveSimpleAgent();
     // Create unique bot ID by appending timestamp and counter to avoid collisions
     const botId = `${botAgent.playerId}-${Date.now()}-${i}`;
@@ -581,7 +587,7 @@ async function handleStartGame(): Promise<void> {
       agent: botAgent,
     };
     connectedPlayers.set(botId, botPlayerInfo);
-    console.log(`Added bot ${botNumber} (ID: ${botId})`);
+    console.log(`Added bot: ${botName} (ID: ${botId})`);
   }
 
   if (connectedPlayers.size < requestedPlayerCount) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export enum ActionType {
   END_PHASE = 'END_PHASE', // Used to indicate phase has ended w/o a specific action being taken by a player
   DEAL = 'DEAL', // When dealer deals cards
   SHUFFLE_DECK = 'SHUFFLE_DECK',
+  AUTO_CRIB_CARD = 'AUTO_CRIB_CARD', // Card(s) automatically dealt to crib from deck (3-player games)
   DISCARD = 'DISCARD',
   PLAY_CARD = 'PLAY_CARD', // player plays a card during pegging phase
   GO = 'GO', // Player says "Go" during pegging phase when they can't play a card

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,6 +106,10 @@ export interface Player extends PlayerIdAndName {
   playedCards: Card[]; // Cards played by the player during the pegging phase
   score: number; // Player's score
   isDealer: boolean; // Whether the player is the dealer for the current round
+  pegPositions: {
+    current: number; // Position of current (front) peg on the board
+    previous: number; // Position of previous (back) peg on the board
+  };
 }
 
 export interface PlayerIdAndName {

--- a/test/CribbageGame.helpers.test.ts
+++ b/test/CribbageGame.helpers.test.ts
@@ -256,23 +256,30 @@ describe('CribbageGame Helper Methods', () => {
   });
 
   describe('getRedactedGameState', () => {
-    it('should return game state (stub implementation)', () => {
+    it('should return redacted game state', () => {
       const redactedState = game.getRedactedGameState('player-1');
       const fullState = game.getGameState();
 
-      // Currently returns full state (stub)
-      expect(redactedState).toBe(fullState);
+      // Redacted state should be a different object (not the same reference)
+      expect(redactedState).not.toBe(fullState);
+      // But should have same basic properties
       expect(redactedState.id).toBe(fullState.id);
       expect(redactedState.players.length).toBe(fullState.players.length);
+      // Deck should be redacted (all UNKNOWN)
+      expect(redactedState.deck.every(c => c === 'UNKNOWN')).toBe(true);
     });
 
     it('should accept any player ID parameter', () => {
       expect(() => {
         game.getRedactedGameState('player-1');
         game.getRedactedGameState('player-2');
-        game.getRedactedGameState('non-existent-player');
       }).not.toThrow();
     });
+
+    it('should throw for non-existent player', () => {
+      expect(() => {
+        game.getRedactedGameState('non-existent-player');
+      }).toThrow('Player non-existent-player not found');
   });
 });
 

--- a/test/CribbageGame.multi-player.test.ts
+++ b/test/CribbageGame.multi-player.test.ts
@@ -1,0 +1,301 @@
+import { CribbageGame } from '../src/core/CribbageGame';
+import { PlayerIdAndName, Phase, ActionType } from '../src/types';
+import { getPlayerCountConfig, getExpectedCribSize } from '../src/gameplay/rules';
+
+describe('CribbageGame - Multi-Player Support', () => {
+  describe('Player Count Validation', () => {
+    it('should accept 2 players', () => {
+      const players: PlayerIdAndName[] = [
+        { id: 'p1', name: 'Player 1' },
+        { id: 'p2', name: 'Player 2' },
+      ];
+      expect(() => new CribbageGame(players)).not.toThrow();
+    });
+
+    it('should accept 3 players', () => {
+      const players: PlayerIdAndName[] = [
+        { id: 'p1', name: 'Player 1' },
+        { id: 'p2', name: 'Player 2' },
+        { id: 'p3', name: 'Player 3' },
+      ];
+      expect(() => new CribbageGame(players)).not.toThrow();
+    });
+
+    it('should accept 4 players', () => {
+      const players: PlayerIdAndName[] = [
+        { id: 'p1', name: 'Player 1' },
+        { id: 'p2', name: 'Player 2' },
+        { id: 'p3', name: 'Player 3' },
+        { id: 'p4', name: 'Player 4' },
+      ];
+      expect(() => new CribbageGame(players)).not.toThrow();
+    });
+
+    it('should reject 1 player', () => {
+      const players: PlayerIdAndName[] = [{ id: 'p1', name: 'Player 1' }];
+      expect(() => new CribbageGame(players)).toThrow(
+        'Invalid player count: 1. Games must have between 2 and 4 players.'
+      );
+    });
+
+    it('should reject 5 players', () => {
+      const players: PlayerIdAndName[] = [
+        { id: 'p1', name: 'Player 1' },
+        { id: 'p2', name: 'Player 2' },
+        { id: 'p3', name: 'Player 3' },
+        { id: 'p4', name: 'Player 4' },
+        { id: 'p5', name: 'Player 5' },
+      ];
+      expect(() => new CribbageGame(players)).toThrow(
+        'Invalid player count: 5. Games must have between 2 and 4 players.'
+      );
+    });
+  });
+
+  describe('2-Player Game Rules', () => {
+    let game: CribbageGame;
+
+    beforeEach(() => {
+      const players: PlayerIdAndName[] = [
+        { id: 'p1', name: 'Player 1' },
+        { id: 'p2', name: 'Player 2' },
+      ];
+      game = new CribbageGame(players);
+      // Set dealer for testing
+      game.getGameState().players[0].isDealer = true;
+    });
+
+    it('should deal 6 cards per player', () => {
+      game.startRound();
+      game.deal();
+      const state = game.getGameState();
+      expect(state.players[0].hand.length).toBe(6);
+      expect(state.players[1].hand.length).toBe(6);
+    });
+
+    it('should have empty crib after startRound', () => {
+      game.startRound();
+      const state = game.getGameState();
+      expect(state.crib.length).toBe(0);
+    });
+
+    it('should expect 4 cards in crib after discards', () => {
+      game.startRound();
+      game.deal();
+      const state = game.getGameState();
+      
+      // Each player discards 2 cards
+      const p1Discards = state.players[0].hand.slice(0, 2);
+      const p2Discards = state.players[1].hand.slice(0, 2);
+      
+      game.discardToCrib('p1', p1Discards);
+      game.discardToCrib('p2', p2Discards);
+      
+      expect(state.crib.length).toBe(4);
+      expect(() => game.completeCribPhase()).not.toThrow();
+    });
+
+    it('should validate expected crib size', () => {
+      expect(getExpectedCribSize(2)).toBe(4);
+    });
+  });
+
+  describe('3-Player Game Rules', () => {
+    let game: CribbageGame;
+
+    beforeEach(() => {
+      const players: PlayerIdAndName[] = [
+        { id: 'p1', name: 'Player 1' },
+        { id: 'p2', name: 'Player 2' },
+        { id: 'p3', name: 'Player 3' },
+      ];
+      game = new CribbageGame(players);
+      // Set dealer for testing
+      game.getGameState().players[0].isDealer = true;
+    });
+
+    it('should auto-deal 1 card to crib during startRound', () => {
+      game.startRound();
+      const state = game.getGameState();
+      
+      // Crib should have 1 auto-dealt card before player dealing
+      expect(state.crib.length).toBe(1);
+      
+      // Verify AUTO_CRIB_CARD event was recorded
+      const history = game.getGameSnapshotHistory();
+      const autoCribEvent = history.find(
+        (s) => s.gameEvent.actionType === ActionType.AUTO_CRIB_CARD
+      );
+      expect(autoCribEvent).toBeDefined();
+      expect(autoCribEvent?.gameEvent.cards?.length).toBe(1);
+    });
+
+    it('should deal 5 cards per player', () => {
+      game.startRound();
+      game.deal();
+      const state = game.getGameState();
+      expect(state.players[0].hand.length).toBe(5);
+      expect(state.players[1].hand.length).toBe(5);
+      expect(state.players[2].hand.length).toBe(5);
+    });
+
+    it('should expect 4 cards in crib after 1 auto + 3 discards', () => {
+      game.startRound();
+      game.deal();
+      const state = game.getGameState();
+      
+      // Crib starts with 1 auto card
+      expect(state.crib.length).toBe(1);
+      
+      // Each player discards 1 card
+      const p1Discards = state.players[0].hand.slice(0, 1);
+      const p2Discards = state.players[1].hand.slice(0, 1);
+      const p3Discards = state.players[2].hand.slice(0, 1);
+      
+      game.discardToCrib('p1', p1Discards);
+      game.discardToCrib('p2', p2Discards);
+      game.discardToCrib('p3', p3Discards);
+      
+      expect(state.crib.length).toBe(4);
+      expect(() => game.completeCribPhase()).not.toThrow();
+    });
+
+    it('should reject completeCribPhase with incorrect crib size', () => {
+      game.startRound();
+      game.deal();
+      const state = game.getGameState();
+      
+      // Only 2 players discard (should have 3 cards total: 1 auto + 2 discards)
+      const p1Discards = state.players[0].hand.slice(0, 1);
+      const p2Discards = state.players[1].hand.slice(0, 1);
+      
+      game.discardToCrib('p1', p1Discards);
+      game.discardToCrib('p2', p2Discards);
+      
+      expect(state.crib.length).toBe(3);
+      expect(() => game.completeCribPhase()).toThrow(
+        'Crib phase not complete. Ensure all players discarded. Expected 4 cards in crib, but found 3.'
+      );
+    });
+
+    it('should validate expected crib size', () => {
+      expect(getExpectedCribSize(3)).toBe(4);
+    });
+
+    it('should redact auto-crib card until counting phase', () => {
+      game.startRound();
+      const state = game.getGameState();
+      
+      // Get redacted snapshot for player 1
+      const redactedSnapshot = game.getRedactedGameSnapshot('p1');
+      
+      // Crib cards should be UNKNOWN before counting
+      expect(redactedSnapshot.gameState.crib.every((c) => c === 'UNKNOWN')).toBe(true);
+      
+      // Find AUTO_CRIB_CARD event and verify it's redacted
+      const history = game.getGameSnapshotHistory();
+      const autoCribEvent = history.find(
+        (s) => s.gameEvent.actionType === ActionType.AUTO_CRIB_CARD
+      );
+      expect(autoCribEvent).toBeDefined();
+      
+      if (autoCribEvent) {
+        const redactedEvent = game.getRedactedGameEvent(autoCribEvent.gameEvent, 'p1');
+        expect(redactedEvent.cards?.every((c) => c === 'UNKNOWN')).toBe(true);
+      }
+    });
+  });
+
+  describe('4-Player Game Rules', () => {
+    let game: CribbageGame;
+
+    beforeEach(() => {
+      const players: PlayerIdAndName[] = [
+        { id: 'p1', name: 'Player 1' },
+        { id: 'p2', name: 'Player 2' },
+        { id: 'p3', name: 'Player 3' },
+        { id: 'p4', name: 'Player 4' },
+      ];
+      game = new CribbageGame(players);
+      // Set dealer for testing
+      game.getGameState().players[0].isDealer = true;
+    });
+
+    it('should not auto-deal cards to crib', () => {
+      game.startRound();
+      const state = game.getGameState();
+      
+      // Crib should be empty (no auto-dealt cards)
+      expect(state.crib.length).toBe(0);
+      
+      // Verify no AUTO_CRIB_CARD event was recorded
+      const history = game.getGameSnapshotHistory();
+      const autoCribEvent = history.find(
+        (s) => s.gameEvent.actionType === ActionType.AUTO_CRIB_CARD
+      );
+      expect(autoCribEvent).toBeUndefined();
+    });
+
+    it('should deal 5 cards per player', () => {
+      game.startRound();
+      game.deal();
+      const state = game.getGameState();
+      expect(state.players[0].hand.length).toBe(5);
+      expect(state.players[1].hand.length).toBe(5);
+      expect(state.players[2].hand.length).toBe(5);
+      expect(state.players[3].hand.length).toBe(5);
+    });
+
+    it('should expect 4 cards in crib after 4 discards', () => {
+      game.startRound();
+      game.deal();
+      const state = game.getGameState();
+      
+      // Each player discards 1 card
+      const p1Discards = state.players[0].hand.slice(0, 1);
+      const p2Discards = state.players[1].hand.slice(0, 1);
+      const p3Discards = state.players[2].hand.slice(0, 1);
+      const p4Discards = state.players[3].hand.slice(0, 1);
+      
+      game.discardToCrib('p1', p1Discards);
+      game.discardToCrib('p2', p2Discards);
+      game.discardToCrib('p3', p3Discards);
+      game.discardToCrib('p4', p4Discards);
+      
+      expect(state.crib.length).toBe(4);
+      expect(() => game.completeCribPhase()).not.toThrow();
+    });
+
+    it('should validate expected crib size', () => {
+      expect(getExpectedCribSize(4)).toBe(4);
+    });
+  });
+
+  describe('Configuration Helper', () => {
+    it('should return correct config for 2 players', () => {
+      const config = getPlayerCountConfig(2);
+      expect(config.handSize).toBe(6);
+      expect(config.discardPerPlayer).toBe(2);
+      expect(config.autoCribCardsFromDeck).toBe(0);
+    });
+
+    it('should return correct config for 3 players', () => {
+      const config = getPlayerCountConfig(3);
+      expect(config.handSize).toBe(5);
+      expect(config.discardPerPlayer).toBe(1);
+      expect(config.autoCribCardsFromDeck).toBe(1);
+    });
+
+    it('should return correct config for 4 players', () => {
+      const config = getPlayerCountConfig(4);
+      expect(config.handSize).toBe(5);
+      expect(config.discardPerPlayer).toBe(1);
+      expect(config.autoCribCardsFromDeck).toBe(0);
+    });
+
+    it('should throw for invalid player count', () => {
+      expect(() => getPlayerCountConfig(1)).toThrow();
+      expect(() => getPlayerCountConfig(5)).toThrow();
+    });
+  });
+});

--- a/test/CribbageGame.setters.test.ts
+++ b/test/CribbageGame.setters.test.ts
@@ -77,7 +77,8 @@ describe('CribbageGame Setter Methods', () => {
   describe('setPhase', () => {
     it('should change phase and log event', () => {
       const initialPhase = game.getGameState().currentPhase;
-      expect(initialPhase).toBe(Phase.DEALING);
+      // Games now start in DEALER_SELECTION phase
+      expect(initialPhase).toBe(Phase.DEALER_SELECTION);
 
       const initialHistoryLength = game.getGameSnapshotHistory().length;
 

--- a/test/SimpleAgent.makeMove.performance.test.ts
+++ b/test/SimpleAgent.makeMove.performance.test.ts
@@ -41,7 +41,9 @@ describe('Agent.makeMove Performance Tests', () => {
       { id: 'opponent', name: 'Opponent' },
     ]);
     
-    // Set up a game state for testing
+    // Set up game properly: select dealer and start round
+    game.getGameState().players[0].isDealer = true;
+    game.startRound();
     game.deal();
     
     // Complete discard phase

--- a/test/SimpleAgent.performance.test.ts
+++ b/test/SimpleAgent.performance.test.ts
@@ -36,7 +36,9 @@ describe('SimpleAgent Performance Tests', () => {
       { id: 'opponent', name: 'Opponent' },
     ]);
     
-    // Set up a game state for testing
+    // Set up game properly: select dealer and start round
+    game.getGameState().players[0].isDealer = true;
+    game.startRound();
     game.deal();
     
     // Complete discard phase
@@ -143,6 +145,8 @@ describe('SimpleAgent Performance Tests', () => {
         { id: 'test-player', name: 'Test Player' },
         { id: 'opponent', name: 'Opponent' },
       ]);
+      game.getGameState().players[0].isDealer = true;
+      game.startRound();
       game.deal();
       const state = game.getGameState();
       const player = state.players.find(p => p.id === 'test-player')!;
@@ -162,6 +166,8 @@ describe('SimpleAgent Performance Tests', () => {
         { id: 'test-player', name: 'Test Player' },
         { id: 'opponent', name: 'Opponent' },
       ]);
+      game.getGameState().players[0].isDealer = true;
+      game.startRound();
       game.deal();
       const state = game.getGameState();
 
@@ -174,6 +180,8 @@ describe('SimpleAgent Performance Tests', () => {
           { id: 'test-player', name: 'Test Player' },
           { id: 'opponent', name: 'Opponent' },
         ]);
+        freshGame.getGameState().players[0].isDealer = true;
+        freshGame.startRound();
         freshGame.deal();
         const freshState = freshGame.getGameState();
 

--- a/test/pegPositions.test.ts
+++ b/test/pegPositions.test.ts
@@ -1,0 +1,100 @@
+import { CribbageGame } from '../src/core/CribbageGame';
+import { Phase } from '../src/types';
+
+describe('pegPositions', () => {
+  it('should initialize pegPositions to 0 for both pegs', () => {
+    const game = new CribbageGame(
+      [
+        { id: 'player1', name: 'Player 1' },
+        { id: 'player2', name: 'Player 2' },
+      ],
+      0
+    );
+
+    const gameState = (game as any).gameState;
+    expect(gameState.players[0].pegPositions).toEqual({
+      current: 0,
+      previous: 0,
+    });
+    expect(gameState.players[1].pegPositions).toEqual({
+      current: 0,
+      previous: 0,
+    });
+  });
+
+  it('should initialize pegPositions with starting score', () => {
+    const game = new CribbageGame(
+      [
+        { id: 'player1', name: 'Player 1' },
+        { id: 'player2', name: 'Player 2' },
+      ],
+      50
+    );
+
+    const gameState = (game as any).gameState;
+    expect(gameState.players[0].pegPositions).toEqual({
+      current: 50,
+      previous: 50,
+    });
+    expect(gameState.players[1].pegPositions).toEqual({
+      current: 50,
+      previous: 50,
+    });
+  });
+
+  it('should update pegPositions when score increases', () => {
+    const game = new CribbageGame(
+      [
+        { id: 'player1', name: 'Player 1' },
+        { id: 'player2', name: 'Player 2' },
+      ],
+      0
+    );
+
+    const gameState = (game as any).gameState;
+    const player = gameState.players[0];
+
+    // Manually update score for testing
+    (game as any).updatePlayerScore(player, 2);
+
+    expect(player.score).toBe(2);
+    expect(player.pegPositions).toEqual({
+      current: 2,
+      previous: 0,
+    });
+  });
+
+  it('should leapfrog pegs when scoring multiple times', () => {
+    const game = new CribbageGame(
+      [
+        { id: 'player1', name: 'Player 1' },
+        { id: 'player2', name: 'Player 2' },
+      ],
+      0
+    );
+
+    const gameState = (game as any).gameState;
+    const player = gameState.players[0];
+
+    // First score
+    (game as any).updatePlayerScore(player, 2);
+    expect(player.pegPositions).toEqual({
+      current: 2,
+      previous: 0,
+    });
+
+    // Second score - pegs should leapfrog
+    (game as any).updatePlayerScore(player, 5);
+    expect(player.pegPositions).toEqual({
+      current: 7,
+      previous: 2,
+    });
+
+    // Third score
+    (game as any).updatePlayerScore(player, 3);
+    expect(player.pegPositions).toEqual({
+      current: 10,
+      previous: 7,
+    });
+  });
+});

--- a/test/pegPositions.test.ts
+++ b/test/pegPositions.test.ts
@@ -97,4 +97,32 @@ describe('pegPositions', () => {
       previous: 7,
     });
   });
+
+  it('should not move pegPositions when score does not change', () => {
+    const game = new CribbageGame(
+      [
+        { id: 'player1', name: 'Player 1' },
+        { id: 'player2', name: 'Player 2' },
+      ],
+      0
+    );
+
+    const gameState = (game as any).gameState;
+    const player = gameState.players[0];
+
+    // First score to move pegs off the starting position
+    (game as any).updatePlayerScore(player, 4);
+    expect(player.pegPositions).toEqual({
+      current: 4,
+      previous: 0,
+    });
+
+    // Zero-point update should not change pegs or score
+    (game as any).updatePlayerScore(player, 0);
+    expect(player.score).toBe(4);
+    expect(player.pegPositions).toEqual({
+      current: 4,
+      previous: 0,
+    });
+  });
 });

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -49,6 +49,9 @@ describe('Type System Tests', () => {
       ]);
 
       // Get a snapshot (by recording an event)
+      // Set up game properly: select dealer and start round
+      game.getGameState().players[0].isDealer = true;
+      game.startRound();
       game.deal();
       const history = game.getGameSnapshotHistory();
       
@@ -81,7 +84,8 @@ describe('Type System Tests', () => {
       game.addDecisionRequest(request);
       expect(game.getPendingDecisionRequests().length).toBe(1);
 
-      // Start a new round
+      // Start a new round (must set dealer first)
+      game.getGameState().players[0].isDealer = true;
       game.startRound();
 
       const pendingRequests = game.getPendingDecisionRequests();


### PR DESCRIPTION
Add pegPositions field to Player interface to maintain both current
and previous peg positions. Pegs automatically leapfrog whenever a
player scores via the new updatePlayerScore() helper method.

This centralizes peg state in GameState rather than requiring
app-side reconstruction from score history. Positions persist across
rounds and initialize to match the starting score.

Updated all 6 score award locations to use the helper:
- Heels scoring
- Pegging play scoring (3 locations)
- Hand and crib counting
- Generic addScoreToPlayer utility

Includes unit tests verifying initialization, leapfrogging, and
multiple scoring rounds.

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
